### PR TITLE
Replace MD5 Hashed Password with native php functions with bcrypt

### DIFF
--- a/system/api/sessionmanager.inc.php
+++ b/system/api/sessionmanager.inc.php
@@ -94,7 +94,7 @@ class System_Api_SessionManager extends System_Api_Base
                         $this->connection->execute( $query, $newHash, $userId );
 
                         $isTemp = false;
-                    } else if ( $passwordHash->isNewHashNeeeded( $hash ) ) {
+                    } else if ( $passwordHash->isNewHashNeeded( $hash ) ) {
                         $newHash = $passwordHash->hashPassword( $password );
 
                         $query = 'UPDATE {users} SET user_passwd = %s WHERE user_id = %d';

--- a/system/core/passwordhash.inc.php
+++ b/system/core/passwordhash.inc.php
@@ -93,7 +93,7 @@ class System_Core_PasswordHash
      *
      * @return bool @c true if a new hash should be calculated.
      */
-    public function isNewHashNeeeded($storedHash)
+    public function isNewHashNeeded($storedHash)
     {
         return password_needs_rehash($storedHash, PASSWORD_BCRYPT);
     }

--- a/system/core/passwordhash.inc.php
+++ b/system/core/passwordhash.inc.php
@@ -1,165 +1,153 @@
 <?php
 /**************************************************************************
-* This file is part of the WebIssues Server program
-* Copyright (C) 2006 Michał Męciński
-* Copyright (C) 2007-2020 WebIssues Team
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-**************************************************************************/
+ * This file is part of the WebIssues Server program
+ * Copyright (C) 2006 Michał Męciński
+ * Copyright (C) 2007-2020 WebIssues Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
 /**
-* Password hashing functions.
-*
-* Based on and compatible with the Portable PHP password hashing framework
-* (http://www.openwall.com/phpass/).
-*
-* A custom hash, starting with '$WI0$' prefix, is used for upgrading old-style
-* MD5 hashes used in version 0.8.
-*/
+ * Password hashing functions.
+ *
+ * Based on and compatible with the Portable PHP password hashing framework
+ * (http://www.openwall.com/phpass/).
+ *
+ * A custom hash, starting with '$WI0$' prefix, is used for upgrading old-style
+ * MD5 hashes used in version 0.8.
+ *
+ * Rehashes if the old hash is using MD5 via the native password_hash function with bcrypt.
+ */
 class System_Core_PasswordHash
 {
-    /** The log2 number of iterations used for password stretching. */
-    const HashCount = 14;
-
     private $itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
     /**
-    * Constructor.
-    */
-    public function __construct()
+     * Calculate a portable hash for the given password.
+     *
+     * @param $password string The plain text password.
+     *
+     * @return false|string
+     */
+    public function hashPassword($password)
     {
+        return password_hash($password, PASSWORD_BCRYPT);
     }
 
     /**
-    * Calculate a portable hash for the given password.
-    * @param $password The plain text password.
-    * @return The calculated hash.
-    */
-    public function hashPassword( $password )
+     * Validate given password against the stored hash.
+     *
+     * @param $password   string The plain text password.
+     * @param $storedHash string The stored hash.
+     *
+     * @return bool @c true if the password is valid, @c false otherwise.
+     */
+    public function checkPassword($password, $storedHash)
     {
-        $setting = '$P$' . $this->itoa64[ self::HashCount ] . $this->generateSalt();
+        if ($this->checkPasswordLegacy($password, $storedHash)) {
+            return true;
+        }
 
-        return $this->calculateHash( $password, $setting );
+        return password_verify($password, $storedHash);
     }
 
     /**
-    * Update old-style password hash to a custom hash.
-    * @param $oldHash The MD5 password hash to update.
-    * @return The calculated hash.
-    */
-    public function updatePasswordHash( $oldHash )
+     * Validate given password against the stored hash with MD5.
+     *
+     * @param $password   string The plain text password.
+     * @param $storedHash string The stored hash.
+     *
+     * @return bool @c true if the password is valid, @c false otherwise.
+     */
+    public function checkPasswordLegacy($password, $storedHash)
     {
-        $setting = '$WI0$' . $this->generateSalt();
-
-        return $this->calculateHash( $oldHash, $setting );
-    }
-
-    /**
-    * Validate given password against the stored hash.
-    * @param $password The plain text password.
-    * @param $storedHash The stored hash.
-    * @return @c true if the password is valid, @c false otherwise.
-    */
-    public function checkPassword( $password, $storedHash )
-    {
-        if ( $storedHash == null )
+        if ($storedHash == null)
             return false;
 
-        if ( substr( $storedHash, 0, 5 ) == '$WI0$' )
-            $password = md5( $password );
+        if (substr($storedHash, 0, 5) == '$WI0$')
+            $password = md5($password);
 
-        $hash = $this->calculateHash( $password, $storedHash );
+        $hash = $this->calculateHashLegacy($password, $storedHash);
 
-        if ( $hash === false )
+        if ($hash === false)
             return false;
 
         return $hash == $storedHash;
     }
 
     /**
-    * Check if a new hash should be calculated.
-    * @param $storedHash The stored hash.
-    * @return @c true if a new hash should be calculated.
-    */
-    public function isNewHashNeeeded( $storedHash )
+     * Check if a new hash should be calculated.
+     *
+     * @param $storedHash string The stored hash.
+     *
+     * @return bool @c true if a new hash should be calculated.
+     */
+    public function isNewHashNeeeded($storedHash)
     {
-        if ( substr( $storedHash, 0, 3 ) != '$P$' )
-            return true;
-
-        if ( strpos( $this->itoa64, $storedHash[ 3 ] ) != self::HashCount )
-            return true;
-
-        return false;
+        return password_needs_rehash($storedHash, PASSWORD_BCRYPT);
     }
 
-    private function calculateHash( $password, $setting )
+    private function calculateHashLegacy($password, $setting)
     {
-        if ( substr( $setting, 0, 3 ) == '$P$' ) {
-            $setting = substr( $setting, 0, 12 );
-            $salt = substr( $setting, 4, 8 );
-            $log2 = strpos( $this->itoa64, $setting[ 3 ] );
-            if ( $log2 < 7 || $log2 > 30 )
+        if (substr($setting, 0, 3) == '$P$') {
+            $setting = substr($setting, 0, 12);
+            $salt = substr($setting, 4, 8);
+            $log2 = strpos($this->itoa64, $setting[3]);
+            if ($log2 < 7 || $log2 > 30)
                 return false;
             $count = 1 << $log2;
-        } else if ( substr( $setting, 0, 5 ) == '$WI0$' ) {
-            $setting = substr( $setting, 0, 13 );
-            $salt = substr( $setting, 5, 8 );
+        } else if (substr($setting, 0, 5) == '$WI0$') {
+            $setting = substr($setting, 0, 13);
+            $salt = substr($setting, 5, 8);
             $count = 256;
         } else {
             return false;
         }
 
-        if ( strlen( $salt ) != 8 )
+        if (strlen($salt) != 8)
             return false;
 
-        $hash = md5( $salt . $password, true );
+        $hash = md5($salt . $password, true);
 
         do {
-            $hash = md5( $hash . $password, true );
-        } while ( --$count );
+            $hash = md5($hash . $password, true);
+        } while (--$count);
 
-        return $setting . $this->encode64( $hash, 16 );
+        return $setting . $this->encode64($hash, 16);
     }
 
-    private function generateSalt()
+    private function encode64($input, $count)
     {
-        $rand = pack( 'S3', mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ) );
+        $output = '';
+        $i = 0;
 
-        return $this->encode64( $rand, 6 );
+        do {
+            $value = ord($input[$i++]);
+            $output .= $this->itoa64[$value & 0x3f];
+            if ($i < $count)
+                $value |= ord($input[$i]) << 8;
+            $output .= $this->itoa64[($value >> 6) & 0x3f];
+            if ($i++ >= $count)
+                break;
+            if ($i < $count)
+                $value |= ord($input[$i]) << 16;
+            $output .= $this->itoa64[($value >> 12) & 0x3f];
+            if ($i++ >= $count)
+                break;
+            $output .= $this->itoa64[($value >> 18) & 0x3f];
+        } while ($i < $count);
+
+        return $output;
     }
-
-	private function encode64( $input, $count )
-	{
-		$output = '';
-		$i = 0;
-
-		do {
-			$value = ord( $input[ $i++ ] );
-			$output .= $this->itoa64[ $value & 0x3f ];
-			if ( $i < $count )
-				$value |= ord( $input[ $i ] ) << 8;
-			$output .= $this->itoa64[ ( $value >> 6 ) & 0x3f ];
-			if ( $i++ >= $count )
-				break;
-			if ( $i < $count )
-				$value |= ord( $input[ $i ] ) << 16;
-			$output .= $this->itoa64[ ( $value >> 12 ) & 0x3f ];
-			if ( $i++ >= $count )
-				break;
-			$output .= $this->itoa64[ ( $value >> 18 ) & 0x3f ];
-		} while ( $i < $count );
-
-		return $output;
-	}
 }


### PR DESCRIPTION
As discussed in https://github.com/mimecorg/webissues/issues/62, this replaces the Hashing functions from [phpass](https://www.openwall.com/phpass) with the >PHP5.5 native functions with the bcrypt algorithm. Some methods from phpass still persist to unsure, that the user can still log in with the MD5 Password hashes.

For checking Password, the MD5 and bcrypt passwords are working, for saving new passwords only bcrypt is being used. `isNewHashNeeded` also only checks for the bcrypt algorithm.

If a user logs in with an MD5 hash, it should be replaced with a bcrypt hash after the first login.